### PR TITLE
Tag Editing with Modal working

### DIFF
--- a/src/components/Tags.jsx
+++ b/src/components/Tags.jsx
@@ -11,7 +11,7 @@ export const Tags = () => {
     },
   ]);
   const [newTag, setNewTag] = useState({ label: "" });
-  const [editTag, setEditTag] = useState({})
+  const [editTag, setEditTag] = useState({});
   const editModal = useRef();
   const deleteModal = useRef();
 
@@ -41,7 +41,10 @@ export const Tags = () => {
   };
 
   const changeTag = async (event, id) => {
-    event.preventDefault()
+    event.preventDefault();
+    const finalValue = {
+      label: editTag.label,
+    };
 
     await fetch(`http://localhost:8000/tags/${id}`, {
       method: "PUT",
@@ -51,15 +54,49 @@ export const Tags = () => {
         }`,
         "Content-Type": "application/json",
       },
-      body: JSON.stringify(editTag),
-    })
-  }
+      body: JSON.stringify(finalValue),
+    });
+
+    const updatedTags = await getAllTags();
+    editModal.current.close();
+    setAllTags(updatedTags);
+    setEditTag({ label: "" });
+  };
 
   return (
     <div className="__tags-container__ flex flex-col w-9/12 items-center">
       <div className="__tags-header__ text-3xl bg-cyan-800 text-white py-2 px-12 self-center translate-x-2 rounded-t-lg">
         Tags
       </div>
+      <dialog
+        className="__edit-modal__ bg-sky-400/90 p-10 font-bold"
+        ref={editModal}
+      >
+        <div>Edit Tag</div>
+        <form>
+          <fieldset>
+            <input className="input-text" value={editTag.label} onChange={(event) => {
+              const copy = { ...editTag}
+              copy.label = event.target.value
+              setEditTag(copy)
+            }}></input>
+          </fieldset>
+          <button
+            className="btn-edit"
+            onClick={(event) => {
+              changeTag(event, editTag.id);
+            }}
+          >
+            Ok
+          </button>
+          <button
+            className="btn-delete"
+            onClick={() => editModal.current.close()}
+          >
+            Cancel
+          </button>
+        </form>
+      </dialog>
       <dialog
         className="__delete-modal__ bg-red-400/90 p-10 font-bold"
         ref={deleteModal}
@@ -80,24 +117,12 @@ export const Tags = () => {
                 className="__tags-item-container__ bg-cyan-500/40 py-1 px-2 text-cyan-950 flex items-center justify-between w-[256px] rounded"
                 key={tag.id}
               >
-                <dialog
-                  className="__edit-modal__ bg-sky-400/90 p-10 font-bold"
-                  ref={editModal}
-                >
-                  <div>Edit Tag</div>
-                  <button className="btn-edit">Ok</button>
-                  <button
-                    className="btn-delete"
-                    onClick={(tag) => {
-
-                    }}
-                  >
-                    Cancel
-                  </button>
-                </dialog>
                 <div>
                   <button
-                    onClick={() => editModal.current.showModal()}
+                    onClick={() => {
+                      setEditTag(tag);
+                      editModal.current.showModal();
+                    }}
                     className="btn-edit"
                   >
                     <img src={editButton} />

--- a/src/components/Tags.jsx
+++ b/src/components/Tags.jsx
@@ -11,6 +11,7 @@ export const Tags = () => {
     },
   ]);
   const [newTag, setNewTag] = useState({ label: "" });
+  const [editTag, setEditTag] = useState({})
   const editModal = useRef();
   const deleteModal = useRef();
 
@@ -39,20 +40,23 @@ export const Tags = () => {
     setNewTag({ label: "" });
   };
 
+  const changeTag = async (event, id) => {
+    event.preventDefault()
+
+    await fetch(`http://localhost:8000/tags/${id}`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Token ${
+          JSON.parse(localStorage.getItem("rare_token")).token
+        }`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(editTag),
+    })
+  }
+
   return (
     <div className="__tags-container__ flex flex-col w-9/12 items-center">
-      <dialog
-        className="__edit-modal__ bg-sky-400/90 p-10 font-bold"
-        ref={editModal}
-      >
-        <div>Edit Modal</div>
-        <button
-          className="btn-delete"
-          onClick={() => editModal.current.close()}
-        >
-          Close Modal
-        </button>
-      </dialog>
       <div className="__tags-header__ text-3xl bg-cyan-800 text-white py-2 px-12 self-center translate-x-2 rounded-t-lg">
         Tags
       </div>
@@ -76,6 +80,21 @@ export const Tags = () => {
                 className="__tags-item-container__ bg-cyan-500/40 py-1 px-2 text-cyan-950 flex items-center justify-between w-[256px] rounded"
                 key={tag.id}
               >
+                <dialog
+                  className="__edit-modal__ bg-sky-400/90 p-10 font-bold"
+                  ref={editModal}
+                >
+                  <div>Edit Tag</div>
+                  <button className="btn-edit">Ok</button>
+                  <button
+                    className="btn-delete"
+                    onClick={(tag) => {
+
+                    }}
+                  >
+                    Cancel
+                  </button>
+                </dialog>
                 <div>
                   <button
                     onClick={() => editModal.current.showModal()}


### PR DESCRIPTION
# Tag Edit modal is functioning, built framework for Delete modal, input tailwind component added for text inputs
## Steps to Accomplish
- With the `useRef()` hook assigned to `editModal `and `deleteModal`, built a dialog JSX element for each modal.
- Built addTag asynchronous function, providing a POST method to `http://localhost:8000/tags` for new tags.
- Added `input-text` custom tailwind component for styling text field inputs.
## Steps to Test
- Fetch and checkout the `nc-tag-edit-function`
- `Code .` into VS code and run `npm run dev` in your terminal if you have not already done so.
- Open your browser and navigate to `http://localhost:3000`
- Ensure the rare API is running
- Click Tag Manager on the navbar
- Click the edit button (pencil) next to a tag of your choice
- Type a new label for the tag and click save
- The tag should have updated
